### PR TITLE
Fix/xpath eval methods

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "axios": "^0.19.2",
     "bulma": "^0.8.1",
     "date-fns": "^2.11.0",
-    "debug": "^4.1.1",
     "enketo-xpathjs": "^1.9.4",
     "fingerprintjs2": "^2.1.0",
     "invariant": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "axios": "^0.19.2",
     "bulma": "^0.8.1",
     "date-fns": "^2.11.0",
+    "debug": "^4.1.1",
     "enketo-xpathjs": "^1.9.4",
     "fingerprintjs2": "^2.1.0",
+    "invariant": "^2.2.4",
     "node-sass": "^4.13.1",
     "numeral": "^2.0.6",
     "postcss-cli": "^7.1.0",
@@ -30,12 +32,14 @@
     "react-scripts": "3.4.1",
     "react-transition-group": "^4.3.0",
     "showdown": "^1.9.1",
-    "xml-js": "^1.6.11"
+    "xml-js": "^1.6.11",
+    "xmlserializer": "^0.6.1"
   },
   "scripts": {
     "start": "REACT_APP_VERSION=$(node -pe 'require(\"./package.json\").version') react-scripts start",
     "build": "REACT_APP_VERSION=$(node -pe 'require(\"./package.json\").version') react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts --inspect-brk test --runInBand --no-cache",
+    "test:watch": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   "scripts": {
     "start": "REACT_APP_VERSION=$(node -pe 'require(\"./package.json\").version') react-scripts start",
     "build": "REACT_APP_VERSION=$(node -pe 'require(\"./package.json\").version') react-scripts build",
-    "test": "react-scripts --inspect-brk test --runInBand --no-cache",
-    "test:watch": "react-scripts test",
+    "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
+    "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
   "devDependencies": {

--- a/src/lib/xpathexp/Compiler.test.js
+++ b/src/lib/xpathexp/Compiler.test.js
@@ -1,0 +1,54 @@
+/* eslint-disable no-template-curly-in-string */
+/* eslint-disable array-callback-return */
+
+import { evalExpression, compileExpression } from "./index"
+
+describe("Xpath compiler tests", () => {
+  test("All test types compile into valid xpath expressions and not throw errors", () => {
+    const model = {
+      test: ["one"],
+    }
+
+    const expressions = [
+      ".=1",
+      ".!=1",
+      ".='one'",
+      ".=''",
+      ".='one'",
+      ".<= date(today())",
+      "count(//models/tested) >= 2",
+      "count-selected(${tested}) >= 1",
+      "selected(${face_contact_outings}, 'other')",
+    ]
+
+    expressions.map(expression => {
+      expect(() => evalExpression(expression, model)).not.toThrow(Error)
+    })
+  })
+
+  test("equality", () => {
+    const expression = "${tested} = 'yes_tested'"
+    expect(compileExpression(expression)).toBe("/models/tested[.='yes_tested']")
+  })
+
+  test("equality or", () => {
+    const expression = "${tested} = 'yes_tested' or ${tested} = 'not'"
+    expect(compileExpression(expression)).toBe(
+      "/models/tested[.='yes_tested'] | /models/tested[.='not']",
+    )
+  })
+
+  test("count-selected", () => {
+    const expression = "count-selected(${tested}) >= 1"
+    expect(compileExpression(expression)).toBe(
+      "count-selected(/models/tested)>=1",
+    )
+  })
+
+  test("selected", () => {
+    const expression = "selected(${tested}, 'other')"
+    expect(compileExpression(expression)).toBe(
+      "selected(/models/tested,'other')",
+    )
+  })
+})

--- a/src/lib/xpathexp/Compiler.test.js
+++ b/src/lib/xpathexp/Compiler.test.js
@@ -34,7 +34,7 @@ describe("Xpath compiler tests", () => {
   test("equality or", () => {
     const expression = "${tested} = 'yes_tested' or ${tested} = 'not'"
     expect(compileExpression(expression)).toBe(
-      "/models/tested[.='yes_tested'] | /models/tested[.='not']",
+      "/models/tested[.='yes_tested'] or /models/tested[.='not']",
     )
   })
 

--- a/src/lib/xpathexp/XPathExp.test.js
+++ b/src/lib/xpathexp/XPathExp.test.js
@@ -310,7 +310,7 @@ describe("Test all relevancy checks", () => {
     expect(result).toBe(true)
   })
 
-  test("If the user has selected none in a multi select make sure it's the only selection", () => {
+  test("If the user has selected none and one other value in a multi select make sure it returns false", () => {
     const expression =
       "selected(${userdetail_conditions}, 'none') = true() and count-selected(${userdetail_conditions}) = 1"
     let result = evalExpression(expression, {

--- a/src/lib/xpathexp/XPathExp.test.js
+++ b/src/lib/xpathexp/XPathExp.test.js
@@ -289,7 +289,7 @@ describe("Test all relevancy checks", () => {
     expect(result).toBe(true)
   })
 
-  test("That super-long expression simon wrote should work", () => {
+  test("That super-long expression simon wrote should work if the user has selected three values", () => {
     const expression =
       "${userdetail_conditions} = '' or \
     (selected(${userdetail_conditions}, 'none') = 'true' and count-selected(${userdetail_conditions}) = 1) \
@@ -299,5 +299,23 @@ describe("Test all relevancy checks", () => {
       userdetail_conditions: "faa laa baa",
     })
     expect(result).toBe(true)
+  })
+
+  test("If the user has selected none in a multi select make sure it's the only selection", () => {
+    const expression =
+      "selected(${userdetail_conditions}, 'none') = true() and count-selected(${userdetail_conditions}) = 1"
+    let result = evalExpression(expression, {
+      userdetail_conditions: "none",
+    })
+    expect(result).toBe(true)
+  })
+
+  test("If the user has selected none in a multi select make sure it's the only selection", () => {
+    const expression =
+      "selected(${userdetail_conditions}, 'none') = true() and count-selected(${userdetail_conditions}) = 1"
+    let result = evalExpression(expression, {
+      userdetail_conditions: "none second",
+    })
+    expect(result).toBe(false)
   })
 })

--- a/src/lib/xpathexp/XPathExp.test.js
+++ b/src/lib/xpathexp/XPathExp.test.js
@@ -1,66 +1,130 @@
-import { checkConstraint, checkRelevant } from "./index"
+/* eslint-disable no-template-curly-in-string */
+/* eslint-disable array-callback-return */
 
-test("Contraint test: not equal to constraint .!='under_14'", () => {
-  const constraint = ".!='under_14'"
+import { checkConstraint, checkRelevant, evalExpression } from "./index"
 
-  const values = [
-    {
-      value: "18_20",
-      expected: true,
-    },
-    {
-      value: 20,
-      expected: true,
-    },
-    {
-      value: "under_14",
-      expected: false,
-    },
-  ]
+describe("Correct data types being passed", () => {
+  const model = {
+    test: ["one"],
+  }
 
-  values.map(i => {
-    let result = checkConstraint(i.value, constraint)
-    expect(result).toBe(i.expected)
+  test("Should throw error on undefined expression", () => {
+    expect(() => evalExpression(undefined, model)).toThrow(Error)
+  })
+
+  test("Should throw error on bad expression type", () => {
+    expect(() => evalExpression(false, model)).toThrow(Error)
   })
 })
 
-// @TODO dynamically generate test dates so that this test doesn't
-// break in 2023
-test("Constraint test: date less than or equal to constraint", () => {
-  const constraint = ".<= date(today())"
+describe("Test all constraints", () => {
+  test("Contraint test: not equal to constraint .!='under_14'", () => {
+    const constraint = ".!='under_14'"
 
-  const values = [
-    {
-      value: "1999-01-01",
-      expected: true,
-    },
-    {
-      value: "2020-01-01",
-      expected: true,
-    },
-    {
-      value: "2023-01-01",
-      expected: false,
-    },
-  ]
+    const values = [
+      {
+        value: "18_20",
+        expected: true,
+      },
+      {
+        value: 20,
+        expected: true,
+      },
+      {
+        value: "under_14",
+        expected: false,
+      },
+    ]
 
-  values.map(i => {
-    let result = checkConstraint(i.value, constraint)
-    expect(result).toBe(i.expected)
+    values.map(i => {
+      let result = checkConstraint(i.value, constraint)
+      expect(result).toBe(i.expected)
+    })
+  })
+
+  // @TODO dynamically generate test dates so that this test doesn't
+  // break in 2023
+  test("date less than or equal to today", () => {
+    const constraint = ".<= date(today())"
+
+    const values = [
+      {
+        value: "1999-01-01",
+        expected: true,
+      },
+      {
+        value: "2020-01-01",
+        expected: true,
+      },
+      {
+        value: "2023-01-01",
+        expected: false,
+      },
+    ]
+
+    values.map(i => {
+      let result = checkConstraint(i.value, constraint)
+      expect(result).toBe(i.expected)
+    })
+  })
+
+  test("count selected one item", () => {
+    const relevance = "count-selected(${tested}) >= 1"
+    // const relevance = "count-selected(//models/tested) >= 1"
+
+    const values = [
+      {
+        value: {
+          tested: "no_tested",
+        },
+        expected: true,
+      },
+
+      {
+        value: {
+          tested: ["yes_tested", "no_tested"],
+        },
+        expected: true,
+      },
+    ]
+
+    values.map(i => {
+      let result = checkConstraint(i.value, relevance)
+      expect(result).toBe(i.expected)
+    })
+  })
+
+  test("count selected two items", () => {
+    // const relevance = "count-selected(${tested}) >= 1"
+    const relevance = "count(//models/tested) >= 2"
+
+    const values = [
+      {
+        value: {
+          tested: "no_tested",
+        },
+        expected: false,
+      },
+
+      {
+        value: {
+          tested: ["first_item", "second_item"],
+        },
+        expected: true,
+      },
+    ]
+
+    values.map(i => {
+      let result = checkConstraint(i.value, relevance)
+      expect(result).toBe(i.expected)
+    })
   })
 })
 
-test("Relevant: Equality test single XML", () => {
-  // eslint-disable-next-line no-template-curly-in-string
-  const relevance = "${tested} = 'yes_tested'"
-
-  const values = [
+describe("Test all relevancy checks", () => {
+  const xmlModel = [
     {
       value: "<tested>no_tested</tested>",
-      expected: false,
-    },
-    {
-      value: "<tested></tested>",
       expected: false,
     },
     {
@@ -69,26 +133,10 @@ test("Relevant: Equality test single XML", () => {
     },
   ]
 
-  values.map(i => {
-    let result = checkRelevant(i.value, relevance)
-    expect(result).toBe(i.expected)
-  })
-})
-
-test("Relevant: Equality test single JSON", () => {
-  // eslint-disable-next-line no-template-curly-in-string
-  const relevance = "${tested} = 'yes_tested'"
-
-  const values = [
+  const jsonModel = [
     {
       value: {
         tested: "no_tested",
-      },
-      expected: false,
-    },
-    {
-      value: {
-        tested: undefined,
       },
       expected: false,
     },
@@ -100,122 +148,75 @@ test("Relevant: Equality test single JSON", () => {
     },
   ]
 
-  values.map(i => {
-    let result = checkRelevant(i.value, relevance)
-    expect(result).toBe(i.expected)
+  test("Equality test single XML", () => {
+    const expression = "${tested} = 'yes_tested'"
+
+    xmlModel.map(i => {
+      let result = evalExpression(expression, i.value)
+      expect(result).toBe(i.expected)
+    })
   })
-})
 
-test("Relevant: Equality test or JSON", () => {
-  // eslint-disable-next-line no-template-curly-in-string
-  const relevance = "${tested} = 'yes_tested' or ${tested} = 'not'"
+  test("Equality test single JSON", () => {
+    const expression = "${tested} = 'yes_tested'"
 
-  const values = [
-    {
-      value: "<tested>no_tested</tested>",
-      expected: false,
-    },
-    {
-      value: "<tested></tested>",
-      expected: false,
-    },
-    {
-      value: "<tested>yes_tested</tested>",
-      expected: true,
-    },
-  ]
-
-  values.map(i => {
-    let result = checkRelevant(i.value, relevance)
-    expect(result).toBe(i.expected)
+    jsonModel.map(i => {
+      let result = evalExpression(expression, i.value)
+      expect(result).toBe(i.expected)
+    })
   })
-})
 
-test("Relevant: Equality test or XML", () => {
-  // eslint-disable-next-line no-template-curly-in-string
-  const relevance = "${tested} = 'yes_tested' or ${tested} = 'not'"
+  test("Equality test or operator XML", () => {
+    const expression = "${tested} = 'yes_tested' or ${tested} = 'not'"
 
-  const values = [
-    {
-      value: {
-        tested: "no_tested",
-      },
-      expected: false,
-    },
-    {
-      value: {
-        tested: undefined,
-      },
-      expected: false,
-    },
-    {
-      value: {
-        tested: "yes_tested",
-      },
-      expected: true,
-    },
-    {
-      value: undefined,
-      expected: false,
-    },
-    {
-      __no_key: "yes_tested",
-      expected: false,
-    },
-  ]
-
-  values.map(i => {
-    let result = checkRelevant(i.value, relevance)
-    expect(result).toBe(i.expected)
+    xmlModel.map(i => {
+      let result = evalExpression(expression, i.value)
+      expect(result).toBe(i.expected)
+    })
   })
-})
 
-test("Relevant: Equality test or blank JSON", () => {
-  // eslint-disable-next-line no-template-curly-in-string
-  const relevance = "${tested} = 'yes_tested' or ${tested} = ''"
+  test("Equality test or operator", () => {
+    const expression = "${tested} = 'yes_tested' or ${tested} = 'not'"
 
-  const values = [
-    {
-      value: "<tested>no_tested</tested>",
-      expected: false,
-    },
-    {
-      value: "<tested></tested>",
-      expected: true,
-    },
-    {
-      value: "<tested>yes_tested</tested>",
-      expected: true,
-    },
-  ]
-
-  values.map(i => {
-    let result = checkRelevant(i.value, relevance)
-    expect(result).toBe(i.expected)
+    jsonModel.map(i => {
+      let result = evalExpression(expression, i.value)
+      expect(result).toBe(i.expected)
+    })
   })
-})
 
-test("Relevant: Equality test or not eq blank JSON", () => {
-  // eslint-disable-next-line no-template-curly-in-string
-  const relevance = "${tested} != 'yes_tested' and ${tested} != ''"
+  test("Equality test or blank", () => {
+    const relevance = "${tested} = 'yes_tested' or ${tested} = ''"
 
-  const values = [
-    {
-      value: "<tested>no_tested</tested>",
-      expected: true,
-    },
-    {
-      value: "<tested></tested>",
-      expected: false,
-    },
-    {
-      value: "<tested>yes_tested</tested>",
-      expected: false,
-    },
-  ]
+    jsonModel.map(i => {
+      let result = checkRelevant(i.value, relevance)
+      expect(result).toBe(i.expected)
+    })
+  })
 
-  values.map(i => {
-    let result = checkRelevant(i.value, relevance)
-    expect(result).toBe(i.expected)
+  test("Test not equal equality", () => {
+    const expression = "${tested} != 'yes_tested'"
+
+    let result = evalExpression(expression, { tested: "yes_tested" })
+    expect(result).toBe(false)
+  })
+
+  test("Test not equal equality combined with or", () => {
+    const expression = "${tested} != 'yes_tested' or ${tested} != '__random'"
+    let result = evalExpression(expression, { tested: "yes_tested" })
+    expect(result).toBe(true)
+  })
+
+  test("Test not equal equality and combinator is true", () => {
+    const expression = "${tested} != 'yes_tested' and ${tested} != ''"
+
+    let result = evalExpression(expression, { tested: "yes_tested" })
+    expect(result).toBe(false)
+  })
+
+  test("Test not equal equality and combinator is false", () => {
+    const expression = "${tested} != 'yes_tested' and ${tested} != ''"
+
+    let result = evalExpression(expression, { tested: "__random string" })
+    expect(result).toBe(true)
   })
 })

--- a/src/lib/xpathexp/XPathExp.test.js
+++ b/src/lib/xpathexp/XPathExp.test.js
@@ -219,4 +219,40 @@ describe("Test all relevancy checks", () => {
     let result = evalExpression(expression, { tested: "__random string" })
     expect(result).toBe(true)
   })
+
+  test("Should have two values selected from a multi-select", () => {
+    const expression = "count-selected(${face_contact_outings}) = 2"
+
+    let result = evalExpression(expression, {
+      face_contact_outings: "one two",
+    })
+    expect(result).toBe(true)
+  })
+
+  test("Should have more than three values selected in a multi-select", () => {
+    const expression = "count-selected(${face_contact_outings}) >= 3"
+
+    let result = evalExpression(expression, {
+      face_contact_outings: "one two three four",
+    })
+    expect(result).toBe(true)
+  })
+
+  test("Should return true if there is a value from a multi-select", () => {
+    const expression = "selected(${face_contact_outings}, 'other')"
+
+    let result = evalExpression(expression, {
+      face_contact_outings: "one two other",
+    })
+    expect(result).toBe(true)
+  })
+
+  test("Should return false if a multi-select does not contain a value", () => {
+    const expression = "selected(${face_contact_outings}, 'other')"
+
+    let result = evalExpression(expression, {
+      face_contact_outings: "one two three",
+    })
+    expect(result).toBe(false)
+  })
 })

--- a/src/lib/xpathexp/XPathExp.test.js
+++ b/src/lib/xpathexp/XPathExp.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-template-curly-in-string */
-/* eslint-disable array-callback-return */
+/* eslint-disable array-callback-return,no-multi-str */
 
 import { checkConstraint, checkRelevant, evalExpression } from "./index"
 
@@ -254,5 +254,50 @@ describe("Test all relevancy checks", () => {
       face_contact_outings: "one two three",
     })
     expect(result).toBe(false)
+  })
+
+  test("A value is selected and only it is selected", () => {
+    const expression =
+      "selected(${userdetail_conditions}, 'none') = 'true' \
+      and count-selected(${userdetail_conditions}) = 1"
+
+    let result = evalExpression(expression, {
+      userdetail_conditions: "none",
+    })
+    expect(result).toBe(true)
+  })
+
+  test("A value is selected but not only it is selected", () => {
+    const expression =
+      "selected(${userdetail_conditions}, 'none') = 'true' \
+      and count-selected(${userdetail_conditions}) = 1"
+
+    let result = evalExpression(expression, {
+      userdetail_conditions: "none baa",
+    })
+    expect(result).toBe(false)
+  })
+
+  test("A value is not selected but more than one other is selected", () => {
+    const expression =
+      "selected(${userdetail_conditions}, 'none') = 'false' \
+      and count-selected(${userdetail_conditions}) >= 1"
+
+    let result = evalExpression(expression, {
+      userdetail_conditions: "faa laa baa",
+    })
+    expect(result).toBe(true)
+  })
+
+  test("That super-long expression simon wrote should work", () => {
+    const expression =
+      "${userdetail_conditions} = '' or \
+    (selected(${userdetail_conditions}, 'none') = 'true' and count-selected(${userdetail_conditions}) = 1) \
+     or (selected(${userdetail_conditions}, 'none') = 'false' and count-selected(${userdetail_conditions}) >= 1)"
+
+    let result = evalExpression(expression, {
+      userdetail_conditions: "faa laa baa",
+    })
+    expect(result).toBe(true)
   })
 })

--- a/src/lib/xpathexp/index.js
+++ b/src/lib/xpathexp/index.js
@@ -50,15 +50,14 @@ export const compileExpression = expression => {
 
   let components = expression.split(/ (and|or) /)
   components = components
-    .map(c =>
-      !!c.match(/\$\{\w+\}/) ? replaceModelVars(c) : replaceOperators(c),
-    )
+    .map(c => (!!c.match(/\$\{\w+\}/) ? replaceModelVars(c) : c))
     .join(" ")
 
   return components
 }
 
-const replaceOperators = o => o.replace("or", "|").replace("and", "and")
+const replaceTypes = o =>
+  o.replace("'true'", "true()").replace("'false'", "false()")
 
 const regReplaceVars = new RegExp(/\$\{([\w_]+)\}/)
 const regShortCutEval = new RegExp(/(\/models\/[\w_]+)(!?=)'([\w_]*)'/, "i")
@@ -71,6 +70,7 @@ const replaceModelVars = expression => {
   exp = exp.replace(/"/g, "'")
   exp = exp.replace(regReplaceVars, "/models/$1")
   exp = exp.replace(regShortCutEval, "$1[.$2'$3']")
+  exp = replaceTypes(exp)
 
   return exp
 }

--- a/src/lib/xpathexp/index.js
+++ b/src/lib/xpathexp/index.js
@@ -1,53 +1,83 @@
 import XPathJS from "enketo-xpathjs"
 import convert from "xml-js"
+import serializer from "xmlserializer"
+import invariant from "invariant"
 
 // @TODO make this binding optional if
 // the default xpath evaluator passes an expression
 XPathJS.bindDomLevel3XPath()
 
 const parser = new DOMParser()
-/**
- * checkConstraint
- *
- * will check an OpenRosa constrains against a single value
- * and return if it matches
- *
- * @param {string} value - the value to match against
- * @param {string} constraint - the OpenRosa constraint
- */
-export const checkConstraint = (value, constraint) => {
-  var xmlString = `<field>${value}</field>`
-  let xmlDoc = parser.parseFromString(xmlString, "text/xml")
 
-  let expression = `field[${constraint}]`
-
-  let res = window.document.evaluate(
-    expression,
-    xmlDoc,
-    null,
-    XPathResult.BOOLEAN_TYPE,
-  )
-
-  return res.booleanValue
-}
+const debug = require("debug")("xpatheval")
 
 /**
  * Will check a string of XML, JSON object with values or
  * a DOMNode against an OpenRosa expression to evaluate if
  * it is true or not
  *
- * @param {string|objcet|DOMNode} nodeOrState
+ * @param {string|object|DOMNode} nodeOrState
  * @param {string} relevancy
  */
-export const checkRelevant = (nodeOrState, relevancy) => {
-  if (!nodeOrState) {
+export const evalExpression = (expression, nodeOrState) => {
+  invariant(nodeOrState, "Invalid node or state")
+  invariant(expression, "Require expression")
+  invariant(typeof expression === "string", "Expression must be a string")
+
+  const xmlDoc = compileModels(nodeOrState)
+
+  expression = compileExpression(expression)
+
+  // console.debug(expression, serializer.serializeToString(xmlDoc))
+
+  let res
+  try {
+    res = window.document.evaluate(
+      expression,
+      xmlDoc,
+      null,
+      XPathResult.BOOLEAN_TYPE,
+    )
+    return res.booleanValue
+  } catch (error) {
+    console.error(`Xpath Error: ${error}`)
     return false
   }
+}
 
-  if (!relevancy || relevancy === undefined || !typeof relevancy === "string") {
-    return false
+export const compileExpression = expression => {
+  if (!expression.match(/ (or|and) /)) {
+    return replaceModelVars(expression)
   }
 
+  let components = expression.split(/ (and|or) /)
+  components = components
+    .map(c =>
+      !!c.match(/\$\{\w+\}/) ? replaceModelVars(c) : replaceOperators(c),
+    )
+    .join(" ")
+
+  return components
+}
+
+const replaceOperators = o => o.replace("or", "|").replace("and", "and")
+
+const regReplaceVars = new RegExp(/\$\{([\w_]+)\}/)
+const regShortCutEval = new RegExp(/(\/models\/[\w_]+)(!?=)'([\w_]*)'/, "i")
+
+const replaceModelVars = expression => {
+  let exp = expression
+  exp = exp.trim()
+
+  exp = exp.replace(/\s/g, "")
+  exp = exp.replace(/"/g, "'")
+  exp = exp.replace(regReplaceVars, "/models/$1")
+  exp = exp.replace(regShortCutEval, "$1[.$2'$3']")
+
+  return exp
+}
+
+const compileModels = nodeOrState => {
   let value
   let xmlDoc
 
@@ -65,52 +95,7 @@ export const checkRelevant = (nodeOrState, relevancy) => {
     xmlDoc = parser.parseFromString(xmlString, "text/xml")
   }
 
-  // @TODO parse variables to expressions
-  let expression = compileExpression(relevancy)
-
-  let res
-
-  // console.debug(expression, value)
-
-  try {
-    res = window.document.evaluate(
-      expression,
-      xmlDoc,
-      null,
-      XPathResult.BOOLEAN_TYPE,
-    )
-  } catch (error) {
-    console.error(`Xpath Error: ${error}`)
-    return false
-  }
-
-  return res.booleanValue
-}
-
-const compileExpression = expression => {
-  if (!expression.match(/ (or|and) /)) {
-    return replaceModelVars(expression)
-  }
-
-  let components = expression.split(/ (and|or) /)
-  components = components
-    .map(c =>
-      !!c.match(/\$\{\w+\}/) ? replaceModelVars(c) : replaceOperators(c),
-    )
-    .join(" ")
-
-  return components
-}
-
-const replaceOperators = o => o.replace("or", "|").replace("and", "and")
-
-const regReplaceMod = new RegExp(/\$\{(\w+)\}(.*)/, "i")
-
-const replaceModelVars = expression => {
-  let exp = expression
-  exp = exp.trim()
-  exp = exp.replace(regReplaceMod, "/models/$1[.$2]")
-  return exp
+  return xmlDoc
 }
 
 const convertObjectToXML = object => {
@@ -118,3 +103,9 @@ const convertObjectToXML = object => {
   var result = convert.json2xml(object, options)
   return result
 }
+
+export const checkConstraint = (node, expression) =>
+  evalExpression(expression, node)
+
+export const checkRelevant = (node, expression) =>
+  evalExpression(expression, node)

--- a/src/lib/xpathexp/index.js
+++ b/src/lib/xpathexp/index.js
@@ -9,8 +9,6 @@ XPathJS.bindDomLevel3XPath()
 
 const parser = new DOMParser()
 
-const debug = require("debug")("xpatheval")
-
 /**
  * Will check a string of XML, JSON object with values or
  * a DOMNode against an OpenRosa expression to evaluate if

--- a/yarn.lock
+++ b/yarn.lock
@@ -12100,6 +12100,11 @@ xmlchars@^2.1.1:
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
+xmlserializer@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/xmlserializer/-/xmlserializer-0.6.1.tgz#14099f60272e16cb608be3758992f998070cc29a"
+  integrity sha512-FNb0eEqqUUbnuvxuHqNuKH8qCGKqxu+558Zi8UzOoQk8Z9LdvpONK+v7m3gpKVHrk5Aq+0nNLsKxu/6OYh7Umw==
+
 xregexp@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/xregexp/-/xregexp-4.3.0.tgz#7e92e73d9174a99a59743f67a4ce879a04b5ae50"


### PR DESCRIPTION
I've left aliases in for the old methods, but the new one is:

```
const evalExpression = (expression, nodeOrState)
```

note I swapped around `expression` and `nodeOrState` arguments because it makes more sense

multi-select should be space-delimited string as the value 