### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build the Docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           REACT_APP_SENTRY_DSN: https://353992084b0d40cb9a6a64292482d90e@sentry.io/5172565
           REACT_APP_API_ENDPOINT: https://api.beatcov-staging.com/

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -12,7 +12,7 @@ jobs:
         id: vars
         run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
       - name: Build the Docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           REACT_APP_SENTRY_DSN: https://353992084b0d40cb9a6a64292482d90e@sentry.io/5172565
           REACT_APP_ANALYTICS_ID: UA-153695048-2


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore